### PR TITLE
add API_Endpoint variable to enable use of local LLM or other service

### DIFF
--- a/Kiki/info.plist
+++ b/Kiki/info.plist
@@ -9049,6 +9049,27 @@ The inspiration to create Kiki came from ToolVox AI. If you know about Shortcuts
 			<key>config</key>
 			<dict>
 				<key>default</key>
+				<string></string>
+				<key>placeholder</key>
+				<string></string>
+				<key>required</key>
+				<false/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string>Leave blank to automatically assign based on the model; for a local LLM tool you can enter something like http://localhost:4891/v1/chat/completions or other API endpoint as required</string>
+			<key>label</key>
+			<string>API Endpoint URL</string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>API_Endpoint</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
 				<string>gpt-3.5-turbo</string>
 				<key>placeholder</key>
 				<string></string>

--- a/Kiki/scripts/request.sh
+++ b/Kiki/scripts/request.sh
@@ -15,6 +15,7 @@ HISTORY_LIMIT=${historyLimit}
 OPENAI_API_KEY="${APIToken_OAI}"
 OPENROUTER_API_KEY="${APIToken_OR}"
 ANTHROPIC_API_KEY="${APIToken_AN}"
+API_ENDPOINT="${API_Endpoint}"
 
 # File Paths
 HISTORY_PATH="${kiki_data}/history/"
@@ -131,8 +132,13 @@ elif [[ "$MODEL" == claude* ]]; then
     )
 fi
 
+# check if API_ENDPOINT is empty, if so assign the API_URL based on the online service sbove
+if [[ -z $API_ENDPOINT ]]; then
+    API_ENDPOINT=$API_URL
+fi
+
 # Make the API request
-response=$(curl -s -X POST "${HEADERS[@]}" -d "$payload" "$API_URL")
+response=$(curl -s -X POST "${HEADERS[@]}" -d "$payload" "$API_ENDPOINT")
 
 # Check for the existence of the "error" field in the response
 if echo "$response" | jq -e '.error' > /dev/null; then


### PR DESCRIPTION
I added a variable `API_Endpoint` to the configuration, if left blank (default) then it should just work as before (where the model name chooses the service). If you add a URL then it will use that instead.

I've tested this with LM Studio and Google's latest Gemma 1.1 2B model, works great. Should also work with GPT4All, ollama and a bunch of WebUIs I never personally tested. There may be an argument to refactor the UI a bit to streamline what service to choose but for the moment this works well.

Should close #2 